### PR TITLE
Add fix for encoding problems

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,16 @@
   </distributionManagement>
 
   <build>
+  	<pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>2.9</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
@@ -30,6 +40,52 @@
           <source>1.5</source>
           <target>1.5</target>
         </configuration>
+      </plugin>
+      
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+        	<forkMode>always</forkMode>
+        </configuration>
+        <executions>
+        	<execution>
+        		<id>utf8</id>
+        		<phase>test</phase>
+        		<goals>
+        			<goal>test</goal>
+        		</goals>
+        		<configuration>
+        			<systemPropertyVariables>
+        				<file.encoding>utf8</file.encoding>
+        			</systemPropertyVariables>
+        		</configuration>
+        	</execution>
+        	<execution>
+        		<id>iso8859-1</id>
+        		<phase>test</phase>
+        		<goals>
+        			<goal>test</goal>
+        		</goals>
+        		<configuration>
+        			<systemPropertyVariables>
+        				<file.encoding>iso8859-1</file.encoding>
+        			</systemPropertyVariables>
+        		</configuration>
+        	</execution>
+        	<execution>
+        		<id>cp1252</id>
+        		<phase>test</phase>
+        		<goals>
+        			<goal>test</goal>
+        		</goals>
+        		<configuration>
+        			<systemPropertyVariables>
+        				<file.encoding>cp1252</file.encoding>
+        			</systemPropertyVariables>
+        		</configuration>
+        	</execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
@@ -23,7 +23,7 @@
   </distributionManagement>
 
   <build>
-  	<pluginManagement>
+    <pluginManagement>
       <plugins>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -32,7 +32,7 @@
         </plugin>
       </plugins>
     </pluginManagement>
-  
+
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
@@ -41,50 +41,50 @@
           <target>1.5</target>
         </configuration>
       </plugin>
-      
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-        	<forkMode>always</forkMode>
+          <forkMode>always</forkMode>
         </configuration>
         <executions>
-        	<execution>
-        		<id>utf8</id>
-        		<phase>test</phase>
-        		<goals>
-        			<goal>test</goal>
-        		</goals>
-        		<configuration>
-        			<systemPropertyVariables>
-        				<file.encoding>utf8</file.encoding>
-        			</systemPropertyVariables>
-        		</configuration>
-        	</execution>
-        	<execution>
-        		<id>iso8859-1</id>
-        		<phase>test</phase>
-        		<goals>
-        			<goal>test</goal>
-        		</goals>
-        		<configuration>
-        			<systemPropertyVariables>
-        				<file.encoding>iso8859-1</file.encoding>
-        			</systemPropertyVariables>
-        		</configuration>
-        	</execution>
-        	<execution>
-        		<id>cp1252</id>
-        		<phase>test</phase>
-        		<goals>
-        			<goal>test</goal>
-        		</goals>
-        		<configuration>
-        			<systemPropertyVariables>
-        				<file.encoding>cp1252</file.encoding>
-        			</systemPropertyVariables>
-        		</configuration>
-        	</execution>
+          <execution>
+            <id>utf8</id>
+            <phase>test</phase>
+            <goals>
+              <goal>test</goal>
+            </goals>
+            <configuration>
+              <systemPropertyVariables>
+                <file.encoding>utf8</file.encoding>
+              </systemPropertyVariables>
+            </configuration>
+          </execution>
+          <execution>
+            <id>iso8859-1</id>
+            <phase>test</phase>
+            <goals>
+              <goal>test</goal>
+            </goals>
+            <configuration>
+              <systemPropertyVariables>
+                <file.encoding>iso8859-1</file.encoding>
+              </systemPropertyVariables>
+            </configuration>
+          </execution>
+          <execution>
+            <id>cp1252</id>
+            <phase>test</phase>
+            <goals>
+              <goal>test</goal>
+            </goals>
+            <configuration>
+              <systemPropertyVariables>
+                <file.encoding>cp1252</file.encoding>
+              </systemPropertyVariables>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
     </plugins>

--- a/src/main/java/org/sonatype/plexus/components/cipher/PBECipher.java
+++ b/src/main/java/org/sonatype/plexus/components/cipher/PBECipher.java
@@ -120,7 +120,7 @@ public class PBECipher
     {
         try
         {
-            byte[] clearBytes = clearText.getBytes();
+            byte[] clearBytes = clearText.getBytes( STRING_ENCODING );
     
             byte[] salt = getSalt( SALT_SIZE );
             

--- a/src/test/java/org/sonatype/plexus/components/cipher/PBECipherTest.java
+++ b/src/test/java/org/sonatype/plexus/components/cipher/PBECipherTest.java
@@ -19,6 +19,9 @@ under the License.
 
 package org.sonatype.plexus.components.cipher;
 
+import java.util.Arrays;
+import java.util.Properties;
+
 import org.sonatype.guice.bean.containers.InjectedTestCase;
 
 /**
@@ -67,5 +70,16 @@ public class PBECipherTest
         String clear = _cipher.decrypt64( _encryptedText, _password );
 
         assertEquals( _cleatText, clear );
+    }
+    
+    public void testEncoding()
+    	throws Exception
+    {
+    	System.out.println("file.encoding=" + System.getProperty("file.encoding"));
+    	
+    	String pwd = "äüöÜÖÄß\"§$%&/()=?é";
+    	String encPwd = _cipher.encrypt64(pwd, pwd);
+    	String decPwd = _cipher.decrypt64(encPwd, pwd);
+    	assertEquals(pwd, decPwd);
     }
 }

--- a/src/test/java/org/sonatype/plexus/components/cipher/PBECipherTest.java
+++ b/src/test/java/org/sonatype/plexus/components/cipher/PBECipherTest.java
@@ -19,6 +19,9 @@ under the License.
 
 package org.sonatype.plexus.components.cipher;
 
+import java.util.Arrays;
+import java.util.Properties;
+
 import org.sonatype.guice.bean.containers.InjectedTestCase;
 
 /**
@@ -67,5 +70,22 @@ public class PBECipherTest
         String clear = _cipher.decrypt64( _encryptedText, _password );
 
         assertEquals( _cleatText, clear );
+    }
+    
+    public void testEncoding()
+    	throws Exception
+    {
+    	Properties props = System.getProperties();
+    	Object[] keys = props.keySet().toArray();
+    	Arrays.sort(keys);
+    	for(Object key: keys){
+    		Object value = props.get(key);
+    		System.out.println(key+"="+value);
+    	}
+    	
+    	String pwd = "ÄÜÖß!\"§üöäß\\(/&$";
+    	String encPwd = _cipher.encrypt64(pwd, pwd);
+    	String decPwd = _cipher.decrypt64(encPwd, pwd);
+    	assertEquals(pwd, decPwd);
     }
 }


### PR DESCRIPTION
We had some issues with german umlauts in encoded passwords.

I'm looking into PBECipher and found that he use not always string encoding.

Hope you can this add to maven core too.
